### PR TITLE
Fix: bulkdatauri value having wrong value

### DIFF
--- a/packages/static-wado-creator/lib/index.js
+++ b/packages/static-wado-creator/lib/index.js
@@ -143,7 +143,7 @@ class StaticWado {
       bulkdata: async (bulkData) => {
         const _bulkDataIndex = bulkDataIndex;
         bulkDataIndex += 1;
-        this.callback.bulkdata(targetId, _bulkDataIndex, bulkData);
+        return this.callback.bulkdata(targetId, _bulkDataIndex, bulkData);
       },
       imageFrame: async (originalImageFrame) => {
         const { imageFrame, id: transcodedId } = await transcodeImageFrame(id, targetId, originalImageFrame, dataSet, this.options);


### PR DESCRIPTION

Includes
- Hotfix: bulkdata generator to wait inner bulkdata to resolve or return its asynchronicity upper layer