### PR TITLE
fix(static-wado):Fix a floating point encoding issue

### DIFF
--- a/packages/static-wado-creator/lib/operation/getDataSet.js
+++ b/packages/static-wado-creator/lib/operation/getDataSet.js
@@ -39,7 +39,8 @@ async function attributeToJS(metadataSrc, tag, dataSet, attr, callback, options,
   const vr = getVR(attr);
   const value = await getValue(dataSet, attr, vr, getDataSet, callback, options, parentAttr);
   const key = tag.substring(1).toUpperCase();
-  if (value == undefined || value.length == 0) {
+  if (value === undefined || value === null || value.length === 0) {
+    if (!vr) return;
     metadata[key] = {
       vr,
     };

--- a/packages/static-wado-creator/lib/operation/getValue.js
+++ b/packages/static-wado-creator/lib/operation/getValue.js
@@ -48,10 +48,14 @@ const getValueInlineUnsignedLong = (dataSet, attr) => {
 };
 
 const getValueInlineFloat = (dataSet, attr) => {
-  if (attr.length > 4) {
+  if (attr.length > 65536 * 4) {
     return getValueInlineBinary(dataSet, attr);
   }
-  return [dataSet.float(attr.tag)];
+  const ret = [];
+  for (let i = 0; i < attr.length / 4; i++) {
+    ret.push(dataSet.float(attr.tag, i));
+  }
+  return ret;
 };
 
 const getValueInlineIntString = (dataSet, attr) => getStrings(dataSet, attr).map((val) => parseInt(val));
@@ -161,6 +165,7 @@ const getValue = async (dataSet, attr, vr, getDataSet, callback, options, parent
     const BulkDataURI = await extractImageFrames(dataSet, attr, vr, callback, options);
     return { BulkDataURI };
   }
+  if (attr.tag === "xfffee00d") return undefined;
   if (attr.items) {
     // sequences
     const result = [];


### PR DESCRIPTION
The encoding of floating point values needs to be as a number for OHIF to display decoding SR annotations, so fixing that for CobbAngle changes.